### PR TITLE
Fix #1 - updating BigInts to properly support values divisible by 256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3
+
+* Bugfix: fixing improperly zero trimming for BigInts divisible by 256
+
 ## 0.0.2
 
 * Updating example code to be detected properly in pub.dev

--- a/lib/src/extensions/bigint_extensions.dart
+++ b/lib/src/extensions/bigint_extensions.dart
@@ -21,13 +21,23 @@ extension BigIntToBytesExtension on BigInt {
     // Break the big int into individual bytes.
     // This conversion results in little endian ordering.
     var number = this;
+    var lastNonZeroByte = -1;
     for (int i = 0; i < bytes; i++) {
-      parsed[i] = number.remainder(_b256).toInt();
+      var byte = number.remainder(_b256).toInt();
+      parsed[i] = byte;
       number = number >> 8;
+
+      if (byte > 0) {
+        lastNonZeroByte = i;
+      }
     }
 
-    // Strip any leading 0's, since they're extraneous at this point
-    var result = parsed.skipWhile((value) => value == 0x00).toList();
+    // Strip any trailing 0's, since they're extraneous at this point
+    List<int> result = parsed;
+    if (lastNonZeroByte >= 0) {
+      result = parsed.sublist(0, lastNonZeroByte + 1);
+    }
+
     // Reverse the list if we want big endian order
     if (endian == Endian.big) {
       result = result.reversed.toList();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: byte_extensions
 description: Extensions for handling common types and converting them to/from byte arrays
-version: 0.0.2
+version: 0.0.3
 homepage:
 repository: https://github.com/flutter-institute/byte_extensions
 issue_tracker: https://github.com/flutter-institute/byte_extensions/issues

--- a/test/bigint_extensions_test.dart
+++ b/test/bigint_extensions_test.dart
@@ -7,7 +7,14 @@ import 'package:byte_extensions/byte_extensions.dart';
 void main() {
   group('BigInt extensions', () {
     test('identity', () {
-      final sut = BigInt.parse('FEDCBA98', radix: 16);
+      var sut = BigInt.parse('FEDCBA98', radix: 16);
+      expect(sut.asBytes().asBigInt(), sut);
+      // Test for numbers divisible by 256 [#1]
+      sut = BigInt.from(256);
+      expect(sut.asBytes().asBigInt(), sut);
+      sut = BigInt.from(65792);
+      expect(sut.asBytes().asBigInt(), sut);
+      sut = BigInt.from(131328);
       expect(sut.asBytes().asBigInt(), sut);
     });
 

--- a/test/double_extensions_test.dart
+++ b/test/double_extensions_test.dart
@@ -79,7 +79,12 @@ void main() {
         // nan
         expect(
           double.nan.asBytes(endian: Endian.big, precision: Precision.double),
-          [0xFF, 0xF8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+          anyOf(
+            // Sign bit 1
+            equals([0xFF, 0xF8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+            // Sign bit 0
+            equals([0x7F, 0xF8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+          ),
         );
 
         // min/max
@@ -152,7 +157,12 @@ void main() {
         // nan
         expect(
           double.nan.asBytes(endian: Endian.big, precision: Precision.float),
-          [0xFF, 0xC0, 0x00, 0x00],
+          anyOf(
+            // Sign bit 1
+            equals([0xFF, 0xC0, 0x00, 0x00]),
+            // Sign bit 0
+            equals([0x7F, 0xC0, 0x00, 0x00]),
+          ),
         );
 
         // min/max


### PR DESCRIPTION
Also updating the NaN tests to support all possible values of the sign bit